### PR TITLE
Make use-debugger more useful

### DIFF
--- a/lisp-unit.lisp
+++ b/lisp-unit.lisp
@@ -536,14 +536,15 @@ assertion.")
 (defun run-test-thunk (code)
   (let ((*pass* 0)
         (*fail* 0))
-    (handler-case (run-code code)
-      (error (condition)
-        (when *print-errors*
-          (print-error condition))
-        (if (use-debugger-p condition)
-            condition
-            (return-from run-test-thunk
-              (values *pass* *fail* :error)))))
+    (handler-bind
+        ((error (lambda (condition)
+                  (when *print-errors*
+                    (print-error condition))
+                  (if (use-debugger-p condition)
+                      condition
+                      (return-from run-test-thunk
+                        (values *pass* *fail* :error condition))))))
+      (run-code code))
     ;; Return the result count
     (values *pass* *fail* nil)))
 


### PR DESCRIPTION
This is a simple patch to allow the original stack in the debugger when run-test-thunk encounters an error.  I actually never get the debugger currently (regardless of use-debugger's setting), but switching to handler-bind is (I believe) correct anyway because it will re-raise the original error in its original context (rather than in the context of run-test-thunk).

Thanks for this useful library, I hope this patch helps improve it for other users.
