### PR TITLE
Discard passing test results

### DIFF
--- a/lisp-unit.lisp
+++ b/lisp-unit.lisp
@@ -90,8 +90,6 @@ functions or even macros does not require reloading any tests.
            :print-failures
            :print-errors
            :summarize-results)
-  ;; behavioral parameters
-  (:export :*keep-passing-asserts*)
   ;; Utility predicates
   (:export :logically-equal :set-equal))
 
@@ -134,11 +132,6 @@ assertion.")
 (defun use-debugger (&optional (flag t))
   "Use the debugger when testing, or not."
   (setq *use-debugger* flag))
-
-(defparameter *keep-passing-asserts* T
-  "when non-nil, passing test assertions will be collected as objects and
-  accessible in test-result objects.  When nil, only the type of the passing
-  assertion will be collected, saving memory."  )
 
 ;;; Global unit test database
 


### PR DESCRIPTION
Only stores counts of passing assertions.

As discussed in #9, feel free to ignore this if you have a different approach in mind.
