### PR TITLE
Some minor improvements.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,12 @@ have been inspired by [JUnit for Java][JUnit].
 * Store all test results in a database object that can be examined
 * Group tests by package for modularity
 * Group tests using tags
+* Signal test completion and return results with the condition.
+
+### Extensions
+
+* Floating point predicates
+* [Test Anything Protocol][TAP] output
 
 ### How to use lisp-unit
 
@@ -31,12 +37,12 @@ loaded using either [Quicklisp][] or [ASDF][].
 2. Load using [Quicklisp][] : `(ql:quickload :lisp-unit)`.
 3. Load using [ASDF][] : `(asdf:load-system :lisp-unit)`.
 
-## Version 0.9.3 Features
+## Version 0.9.4 Features
 
-A comprehensive test results database has been implemented for Version
-0.9.3. `run-tests` and `run-tags` return the test results database
-object. Two new functions have been added for examining the results,
-`print-failures` and `print-errors`.
+Output for the [Test Anything Protocol][TAP] has been implemented as
+an extension by [Ryan Davis][ryepup] of AccelerationNet. Ryan is also
+responsible for the signal test completion feature that is used for
+the [TAP][] output.
 
 ## Version 1 Remaining Tasks
 
@@ -47,7 +53,6 @@ object. Two new functions have been added for examining the results,
 * Fixtures
 * Test Suites
 * Benchmarking tools
-* Test Anything Protocol(TAP) support.
 
 [orig]: <http://www.cs.northwestern.edu/academics/courses/325/readings/lisp-unit.html>
   "Original Lisp Unit"
@@ -56,3 +61,14 @@ object. Two new functions have been added for examining the results,
 [JUnit]: <http://www.junit.org> "JUnit"
 [Quicklisp]: <http://www.quicklisp.org> "Quicklisp"
 [ASDF]: <http://common-lisp.net/project/asdf/> "ASDF"
+[TAP]: <http://testanything.org/> "Test Anything Protocol"
+
+## 0.9.4 Acknowledgments
+
+* [Ryan Davis][ryepup] for the TAP extension and signaling test completion.
+* [Russ Tyndall][bobbysmith007] for cleaning up the use-debugger option.
+* [Mark Cox][markcox80] for catching a lisp-unit bug in CCL.
+
+[ryepup]: <https://github.com/ryepup> "Ryan Davis"
+[bobbysmith007]: <https://github.com/bobbysmith007> "Russ Tyndall"
+[markcox80]: <https://github.com/markcox80> "Mark Cox"

--- a/extensions/floating-point.lisp
+++ b/extensions/floating-point.lisp
@@ -427,6 +427,7 @@ comparison of the relative error is less than epsilon."
   "Return the norm of the vector according to the measure."
   (%norm data measure))
 
+;;; FIXME : Is the entrywise norm of an array useful or confusing?
 (defmethod norm ((data array) &optional (measure *measure*))
   "Return the entrywise norm of the array according to the measure."
   (%norm

--- a/lisp-unit.lisp
+++ b/lisp-unit.lisp
@@ -188,18 +188,20 @@ assertion.")
 
 (defmacro define-test (name &body body)
   "Store the test in the test database."
-  (multiple-value-bind (doc tag code) (parse-body body)
-    `(let ((doc (or ,doc (string ',name))))
-       (setf
-        ;; Unit test
-        (gethash ',name (package-table *package* t))
-        (make-instance 'unit-test :doc doc :code ',code))
-       ;; Tags
-       (loop for tag in ',tag do
-             (pushnew
-              ',name (gethash tag (package-tags *package* t))))
-       ;; Return the name of the test
-       ',name)))
+  (let ((qname (gensym "NAME-")))
+    (multiple-value-bind (doc tag code) (parse-body body)
+      `(let* ((,qname ',name)
+              (doc (or ,doc (string ,qname))))
+         (setf
+          ;; Unit test
+          (gethash ,qname (package-table *package* t))
+          (make-instance 'unit-test :doc doc :code ',code))
+         ;; Tags
+         (loop for tag in ',tag do
+               (pushnew
+                ,qname (gethash tag (package-tags *package* t))))
+         ;; Return the name of the test
+         ,qname))))
 
 ;;; Manage tests
 

--- a/lisp-unit.lisp
+++ b/lisp-unit.lisp
@@ -199,6 +199,8 @@ assertion.")
 
 (defmacro define-test (name &body body)
   "Store the test in the test database."
+  (unless (symbolp name)
+    (error "The first argument to DEFINE-TEST should be a symbol."))
   (let ((qname (gensym "NAME-")))
     (multiple-value-bind (doc tag code) (parse-body body)
       `(let* ((,qname ',name)

--- a/lisp-unit.lisp
+++ b/lisp-unit.lisp
@@ -685,20 +685,21 @@ assertion.")
 
 (defun %run-all-thunks (&optional (package *package*))
   "Run all of the test thunks in the package."
-  (loop
-   with results = (make-instance 'test-results-db)
-   for test-name being each hash-key in (package-table package)
-   using (hash-value unit-test)
-   if unit-test do
-   (record-result test-name (code unit-test) results)
-   else do
-   (push test-name (missing-tests results))
-   ;; Summarize and return the test results
-   finally
-   (when *signal-results*
-     (signal 'test-run-complete :results results))
-   (summarize-results results)
-   (return results)))
+  (when (hash-table-p (package-table package))
+    (loop
+       with results = (make-instance 'test-results-db)
+       for test-name being each hash-key in (package-table package)
+       using (hash-value unit-test)
+       if unit-test do
+	 (record-result test-name (code unit-test) results)
+       else do
+	 (push test-name (missing-tests results))
+       ;; Summarize and return the test results
+       finally
+	 (when *signal-results*
+	   (signal 'test-run-complete :results results))
+	 (summarize-results results)
+	 (return results))))
 
 (defun %run-thunks (test-names &optional (package *package*))
   "Run the list of test thunks in the package."


### PR DESCRIPTION
- Add a new ASSERT-NIL assertion form.  This is, of course, equivalent to ASSERT-FALSE.  But names matter; without knowing your API in full detail I found myself wanting to write ASSERT-NIL to check that a list of results is NIL, but I had to use ASSERT-FALSE, which is (psychologically) not the same thing (even though for the purpose of evaluating values logically falsity = NIL).
- Clean up the various specializations on the RECORD-FAILURE generic function.  On CCL 1.9, this particular practice of using CALL-NEXT-METHOD was leading to errors (specifically, the list of applicable methods was changing because the first argument was going from a known symbol [via the EQL specializer] to an unknown symbol, i.e., the list of applicable methods was changing from a list of length 2 to a list of length 1.
- In .gitignore, ignore fasls generated by a (64-bit) CCL.
- Use HASH-TABLE-P to do some sanity checks on the tags and test tables.
- Trim some unnecessary end-of-line whitespace.