### PR TITLE
added assert-test macro

### DIFF
--- a/lisp-unit.lisp
+++ b/lisp-unit.lisp
@@ -67,6 +67,7 @@ functions or even macros does not require reloading any tests.
            :assert-prints
            :assert-expands
            :assert-true
+	   :assert-test
            :assert-false
            :assert-error)
   ;; Functions for managing tests
@@ -380,6 +381,31 @@ assertion.")
                     tag (package-name package))))))
 
 ;;; Assert macros
+
+(defmacro assert-test (form)
+  "This is a more lispy test assertion.  It logically tests for TRUE, but records a
+more meaningful failure than ASSERT-TRUE, by also recording (and consequently reporting)
+each of the arguments to the function call.  It is assumed that the function call being
+tested has LAMBDA semantics as opposed to macro semantics.  E.g., Here is some example
+output if a test fails.
+(ASSERT-TEST (IMAGE-EQUAL (IMAGE-LOAD IN) (IMAGE-LOAD OUT)))
+-->
+ | Failed Form: (IMAGE-EQUAL (IMAGE-LOAD IN) (IMAGE-LOAD OUT))
+ | Expected T but saw NIL
+ | (IMAGE-LOAD IN) => #<IMAGE-RAW of (BINARY)(16 32)>
+ | (IMAGE-LOAD OUT) => #<IMAGE-RAW of (BINARY)(16 32)>
+"
+  (let ((args (gensym))
+	(fname (gensym)))
+    `(let ((,args (list ,@(cdr form)))
+	   (,fname ',(car form)))
+       (internal-assert :result ; type
+			',form   ; form -- printable
+			(lambda () (apply ,fname ,args))   ; body -- evaluatable
+			(lambda () t)       ; expected results
+			(lambda () (mapcan #'list ',(cdr form) ,args))     ; extras
+			#'EQL
+		      ))))
 
 (defmacro assert-eq (expected form &rest extras)
   "Assert whether expected and form are EQ."


### PR DESCRIPTION
I don't like having to always decide which assertion function i want to use.  I'd like lisp to decide it for me.
Rather than using (assert-equal ...) ( assert-< ...) or (assert-eq ...), I'd rather just use something like
the following.

(assert-test (equal form1 form2))
(assert-test (< form1 form2))
(assert-test (eq form1 form2))

In fact, this PR introduces the ASSERT-TEST macro which does just that.
If the assertion fails, the reported failure message indicates the failure, but also reports
the values of each of the arguments to the function.

You may use any lambda function you want; you are not limited to using the ones LISP-UNIT knows about.  E.g., (assert-test (my-equivalence-function form1 form2 form3))
as long as my-equivalence-function is a function which behaves as if defined by defun/defmethod as opposed to defmacro.

The expansion of the ASSERT-TEST macro assures that each of the arguments is evaluated only once, and that they are evaluated in the correct order.

Here is some example output:




```
 | Failed Form: (= DIFFS 0)
 | Expected T but saw NIL
 | DIFFS => 40
 | 0 => 0
 |
 | Failed Form: (= SAMES (COUNT-SITES IMAGE-OUT))
 | Expected T but saw NIL
 | SAMES => 472
 | (COUNT-SITES IMAGE-OUT) => 512
 |
 | Failed Form: (= SAMES (COUNT-SITES IMAGE-IN))
 | Expected T but saw NIL
 | SAMES => 472
 | (COUNT-SITES IMAGE-IN) => 512
 |
 | Failed Form: (IMAGE-EQUAL (IMAGE-LOAD IN) (IMAGE-LOAD OUT))
 | Expected T but saw NIL
 | (IMAGE-LOAD IN) => #<IMAGE-RAW of (BINARY)(16 32)>
 | (IMAGE-LOAD OUT) => #<IMAGE-RAW of (BINARY)(16 32)>
 |
```