### PR TITLE
Fix for slime

### DIFF
--- a/lisp-unit.lisp
+++ b/lisp-unit.lisp
@@ -462,7 +462,7 @@ output if a test fails.
   (let ((args (gensym))
 	(fname (gensym)))
     `(let ((,args (list ,@(cdr form)))
-	   (,fname ',(car form)))
+	   (,fname #',(car form)))
        (internal-assert
         :result ',form
         (lambda () (apply ,fname ,args)) ; Evaluate the form

--- a/lisp-unit.lisp
+++ b/lisp-unit.lisp
@@ -442,7 +442,8 @@ output if a test fails.
 
 (defmacro assert-false (form &rest extras)
   "Assert whether the form is false."
-  `(expand-assert :result ,form ,form nil ,extras))
+  (let ((extras `(,@(cdr form) ,@extras)))
+    `(expand-assert :result ,form ,form nil ,extras)))
 
 (defmacro assert-equality (test expected form &rest extras)
   "Assert whether expected and form are equal according to test."
@@ -455,7 +456,8 @@ output if a test fails.
 
 (defmacro assert-true (form &rest extras)
   "Assert whether the form is true."
-  `(expand-assert :result ,form ,form t ,extras))
+  (let ((extras `(,@(cdr form) ,@extras)))
+    `(expand-assert :result ,form ,form t ,extras)))
 
 (defmacro expand-assert (type form body expected extras &key (test '#'eql))
   "Expand the assertion to the internal format."

--- a/lisp-unit.lisp
+++ b/lisp-unit.lisp
@@ -57,7 +57,8 @@ functions or even macros does not require reloading any tests.
   ;; Print parameters
   (:export :*print-summary*
            :*print-failures*
-           :*print-errors*)
+           :*print-errors*
+           :*summarize-results*)
   ;; Forms for assertions
   (:export :assert-eq
            :assert-eql
@@ -121,6 +122,9 @@ functions or even macros does not require reloading any tests.
 
 (defparameter *print-errors* nil
   "Print error messages if non-NIL.")
+
+(defparameter *summarize-results* t
+  "Summarize all of the unit test results.")
 
 (defparameter *use-debugger* nil
   "If not NIL, enter the debugger when an error is encountered in an
@@ -790,7 +794,8 @@ assertion.")
      finally
      (when *signal-results*
        (signal 'test-run-complete :results results))
-     (summarize-results results)
+     (when *summarize-results*
+       (summarize-results results))
      (return results))))
 
 (defun %run-thunks (test-names &optional (package *package*))
@@ -807,7 +812,8 @@ assertion.")
      finally
      (when *signal-results*
        (signal 'test-run-complete :results results))
-     (summarize-results results)
+     (when *summarize-results*
+       (summarize-results results))
      (return results))))
 
 (defun run-tests (&optional (test-names :all) (package *package*))

--- a/lisp-unit.lisp
+++ b/lisp-unit.lisp
@@ -227,6 +227,9 @@ assertion.")
     :type string
     :initarg :doc
     :reader doc)
+   (thunk
+    :type (function () t)
+    :initarg :thunk)
    (code
     :type list
     :initarg :code
@@ -287,7 +290,7 @@ assertion.")
          (setf
           ;; Unit test
           (gethash ,qname (package-table package t))
-          (make-instance 'unit-test :doc doc :code ',code))
+          (make-instance 'unit-test :doc doc :code ',code :thunk (lambda () ,@body)))
          ;; Tags
          (loop
           for tag in ',tag do

--- a/lisp-unit.lisp
+++ b/lisp-unit.lisp
@@ -851,7 +851,7 @@ If MERGE is NIL, then an error is signalled when a conflict occurs."
    for new-results in all-results do
    (nappend-test-results-db
     accumulated-test-results-db new-results :merge merge)
-   finally return accumulated-test-results-db))
+   finally (return accumulated-test-results-db)))
 
 ;;; Run the tests
 


### PR DESCRIPTION
This fix allows C-c C-c in slime to check the code.
Previously the code was quoted in the macro expansion, so the compiler could not check it.
