### PR TITLE
Test multiple packages

### DIFF
--- a/lisp-unit.lisp
+++ b/lisp-unit.lisp
@@ -462,7 +462,7 @@ output if a test fails.
   (let ((args (gensym))
 	(fname (gensym)))
     `(let ((,args (list ,@(cdr form)))
-	   (,fname ',(car form)))
+	   (,fname #',(car form)))
        (internal-assert
         :result ',form
         (lambda () (apply ,fname ,args)) ; Evaluate the form

--- a/lisp-unit.lisp
+++ b/lisp-unit.lisp
@@ -906,49 +906,54 @@ If MERGE is NIL, then an error is signalled when a conflict occurs."
   (:documentation
    "Signaled when a test run is finished."))
 
-(defun %run-all-thunks (&optional (package *package*))
+(defun %run-all-thunks (&optional (packages (list *package*)))
   "Run all of the test thunks in the package."
-  (with-package-table (table package)
-    (loop
-     with results = (make-instance 'test-results-db)
-     for test-name being each hash-key in table
-     using (hash-value unit-test)
-     if unit-test do
-     (record-result test-name (code unit-test) results)
-     else do
-     (push test-name (missing-tests results))
-     ;; Summarize and return the test results
-     finally
-     (when *signal-results*
-       (signal 'test-run-complete :results results))
-     (when *summarize-results*
-       (summarize-results results))
-     (return results))))
+  (when (and packages (atom packages))
+    (setf packages (list packages)))
+  (let ((results (make-instance 'test-results-db)))
+    (dolist (package packages)
+      (with-package-table (table package)
+	(loop
+	  for test-name being each hash-key in table
+	    using (hash-value unit-test)
+	  if unit-test do
+	    (record-result test-name (code unit-test) results)
+	  else do
+	    (push test-name (missing-tests results)))))
+    ;; Summarize and return the test results
+    (when *signal-results*
+      (signal 'test-run-complete :results results))
+    (when *summarize-results*
+      (summarize-results results))
+    results))
 
-(defun %run-thunks (test-names &optional (package *package*))
-  "Run the list of test thunks in the package."
-  (with-package-table (table package)
-    (loop
-     with results = (make-instance 'test-results-db)
-     for test-name in test-names
-     as unit-test = (gethash test-name table)
-     if unit-test do
-     (record-result test-name (code unit-test) results)
-     else do
-     (push test-name (missing-tests results))
-     finally
-     (when *signal-results*
-       (signal 'test-run-complete :results results))
-     (when *summarize-results*
-       (summarize-results results))
-     (return results))))
+(defun %run-thunks (test-names &optional (packages (list *package*)))
+  "Run the list of test thunks in the packages."
+  (when (and packages (atom packages))
+    (setf packages (list packages)))
+  (let ((results (make-instance 'test-results-db)))
+    (dolist (package packages)
+      (with-package-table (table package)
+	(loop
+	  for test-name in test-names
+	  as unit-test = (gethash test-name table)
+	  if unit-test do
+	    (record-result test-name (code unit-test) results)
+	  else do
+	    (push test-name (missing-tests results)))))
+    (when *signal-results*
+      (signal 'test-run-complete :results results))
+    (when *summarize-results*
+      (summarize-results results))
+    results))
 
-(defun run-tests (&optional (test-names :all) (package *package*))
+
+(defun run-tests (&optional (test-names :all) (packages (list *package*)))
   "Run the specified tests in package."
   (reset-counters)
   (if (eq :all test-names)
-      (%run-all-thunks package)
-      (%run-thunks test-names package)))
+      (%run-all-thunks packages)
+      (%run-thunks test-names packages)))
 
 (defun run-tags (&optional (tags :all) (package *package*))
   "Run the tests associated with the specified tags in package."

--- a/lisp-unit.lisp
+++ b/lisp-unit.lisp
@@ -442,7 +442,8 @@ output if a test fails.
 
 (defmacro assert-false (form &rest extras)
   "Assert whether the form is false."
-  `(expand-assert :result ,form ,form nil ,extras))
+  (let ((extras `(,@(cdr form) ,@extras)))
+    `(expand-assert :result ,form ,form nil ,extras)))
 
 (defmacro assert-equality (test expected form &rest extras)
   "Assert whether expected and form are equal according to test."
@@ -455,7 +456,8 @@ output if a test fails.
 
 (defmacro assert-true (form &rest extras)
   "Assert whether the form is true."
-  `(expand-assert :result ,form ,form t ,extras))
+  (let ((extras `(,@(cdr form) ,@extras)))
+    `(expand-assert :result ,form ,form t ,extras)))
 
 (defmacro expand-assert (type form body expected extras &key (test '#'eql))
   "Expand the assertion to the internal format."

--- a/lisp-unit.lisp
+++ b/lisp-unit.lisp
@@ -57,7 +57,8 @@ functions or even macros does not require reloading any tests.
   ;; Print parameters
   (:export :*print-summary*
            :*print-failures*
-           :*print-errors*)
+           :*print-errors*
+           :*summarize-results*)
   ;; Forms for assertions
   (:export :assert-eq
            :assert-eql
@@ -121,6 +122,9 @@ functions or even macros does not require reloading any tests.
 
 (defparameter *print-errors* nil
   "Print error messages if non-NIL.")
+
+(defparameter *summarize-results* t
+  "Summarize all of the unit test results.")
 
 (defparameter *use-debugger* nil
   "If not NIL, enter the debugger when an error is encountered in an
@@ -790,7 +794,8 @@ assertion.")
      finally
      (when *signal-results*
        (signal 'test-run-complete :results results))
-     (summarize-results results)
+     (when *summarize-results*
+       (summarize-results results))
      (return results))))
 
 (defun %run-thunks (test-names &optional (package *package*))
@@ -807,7 +812,8 @@ assertion.")
      finally
      (when *signal-results*
        (signal 'test-run-complete :results results))
-     (summarize-results results)
+     (when *summarize-results*
+       (summarize-results results))
      (return results))))
 
 (defun run-tests (&optional (test-names :all) (package *package*))

--- a/lisp-unit.lisp
+++ b/lisp-unit.lisp
@@ -851,7 +851,7 @@ If MERGE is NIL, then an error is signalled when a conflict occurs."
    for new-results in all-results do
    (nappend-test-results-db
     accumulated-test-results-db new-results :merge merge)
-   finally return accumulated-test-results-db))
+   finally (return accumulated-test-results-db)))
 
 ;;; Run the tests
 


### PR DESCRIPTION
I didn't find a way with lisp-unit to run the unit tests in multiple packages and have them summarized together.

I've now updated the public functions run-tests so that its optional argument is a package designator (as before) or a list of package designators.  And I've modified the functions %run-all-thunks and %run-thunks to iterate through the designated list of packages, but summarizing only one rather than once per package.