### PR TITLE
print-object: remove spurious new line

### DIFF
--- a/lisp-unit.lisp
+++ b/lisp-unit.lisp
@@ -772,7 +772,7 @@ assertion.")
         (fail (fail object))
         (exerr (exerr object)))
     (format
-     stream "#<~A Total(~D) Passed(~D) Failed(~D) Errors(~D)>~%"
+     stream "#<~A Total(~D) Passed(~D) Failed(~D) Errors(~D)>"
      (class-name (class-of object))
      (+ pass fail) pass fail exerr)))
 


### PR DESCRIPTION
Cosmetic fix. Printer is responsible for adding new lines for too expressions by itself what leads to repeating new lines when test results are printed in a list:

```
> (list
   (lisp-unit:run-tests :all :tests.ce1)
   (lisp-unit:run-tests :all :tests.ce2)
   (lisp-unit:run-tests :all :itests.ce3))
STUB-TEST: 1 assertions passed, 0 failed.

Unit Test Summary
 | 1 assertions total
 | 1 passed
 | 0 failed
 | 0 execution errors
 | 0 missing tests

STUB-TEST: 1 assertions passed, 0 failed.

Unit Test Summary
 | 1 assertions total
 | 1 passed
 | 0 failed
 | 0 execution errors
 | 0 missing tests

STUB-TEST: 0 assertions passed, 1 failed.

Unit Test Summary
 | 1 assertions total
 | 0 passed
 | 1 failed
 | 0 execution errors
 | 0 missing tests

(#<TEST-RESULTS-DB Total(1) Passed(1) Failed(0) Errors(0)>

 #<TEST-RESULTS-DB Total(1) Passed(1) Failed(0) Errors(0)>

 #<TEST-RESULTS-DB Total(1) Passed(0) Failed(1) Errors(0)>
)
```