### PR TITLE
don't funcall non-funcallable object

### DIFF
--- a/lisp-unit.lisp
+++ b/lisp-unit.lisp
@@ -469,7 +469,7 @@ assertion.")
            ;; Report function arguments
            (internal-assert
             :result ',form
-            (lambda () (apply ,fname ,args)) ; Evaluate the form
+            (lambda () ,form) ; Evaluate the form ; JN just insert ,form rather than (funcall ,fname ...).  Because, we are not sure that fname is funcallable
             (lambda () ,t-or-f)
             ;; Concatenate the args with the extras
             (lambda ()

--- a/lisp-unit.lisp
+++ b/lisp-unit.lisp
@@ -906,49 +906,54 @@ If MERGE is NIL, then an error is signalled when a conflict occurs."
   (:documentation
    "Signaled when a test run is finished."))
 
-(defun %run-all-thunks (&optional (package *package*))
+(defun %run-all-thunks (&optional (packages (list *package*)))
   "Run all of the test thunks in the package."
-  (with-package-table (table package)
-    (loop
-     with results = (make-instance 'test-results-db)
-     for test-name being each hash-key in table
-     using (hash-value unit-test)
-     if unit-test do
-     (record-result test-name (code unit-test) results)
-     else do
-     (push test-name (missing-tests results))
-     ;; Summarize and return the test results
-     finally
-     (when *signal-results*
-       (signal 'test-run-complete :results results))
-     (when *summarize-results*
-       (summarize-results results))
-     (return results))))
+  (when (and packages (atom packages))
+    (setf packages (list packages)))
+  (let ((results (make-instance 'test-results-db)))
+    (dolist (package packages)
+      (with-package-table (table package)
+	(loop
+	  for test-name being each hash-key in table
+	    using (hash-value unit-test)
+	  if unit-test do
+	    (record-result test-name (code unit-test) results)
+	  else do
+	    (push test-name (missing-tests results)))))
+    ;; Summarize and return the test results
+    (when *signal-results*
+      (signal 'test-run-complete :results results))
+    (when *summarize-results*
+      (summarize-results results))
+    results))
 
-(defun %run-thunks (test-names &optional (package *package*))
-  "Run the list of test thunks in the package."
-  (with-package-table (table package)
-    (loop
-     with results = (make-instance 'test-results-db)
-     for test-name in test-names
-     as unit-test = (gethash test-name table)
-     if unit-test do
-     (record-result test-name (code unit-test) results)
-     else do
-     (push test-name (missing-tests results))
-     finally
-     (when *signal-results*
-       (signal 'test-run-complete :results results))
-     (when *summarize-results*
-       (summarize-results results))
-     (return results))))
+(defun %run-thunks (test-names &optional (packages (list *package*)))
+  "Run the list of test thunks in the packages."
+  (when (and packages (atom packages))
+    (setf packages (list packages)))
+  (let ((results (make-instance 'test-results-db)))
+    (dolist (package packages)
+      (with-package-table (table package)
+	(loop
+	  for test-name in test-names
+	  as unit-test = (gethash test-name table)
+	  if unit-test do
+	    (record-result test-name (code unit-test) results)
+	  else do
+	    (push test-name (missing-tests results)))))
+    (when *signal-results*
+      (signal 'test-run-complete :results results))
+    (when *summarize-results*
+      (summarize-results results))
+    results))
 
-(defun run-tests (&optional (test-names :all) (package *package*))
+
+(defun run-tests (&optional (test-names :all) (packages (list *package*)))
   "Run the specified tests in package."
   (reset-counters)
   (if (eq :all test-names)
-      (%run-all-thunks package)
-      (%run-thunks test-names package)))
+      (%run-all-thunks packages)
+      (%run-thunks test-names packages)))
 
 (defun run-tags (&optional (tags :all) (package *package*))
   "Run the tests associated with the specified tags in package."

--- a/lisp-unit.lisp
+++ b/lisp-unit.lisp
@@ -921,7 +921,11 @@ If MERGE is NIL, then an error is signalled when a conflict occurs."
 	  for test-name being each hash-key in table
 	    using (hash-value unit-test)
 	  if unit-test do
-	    (record-result test-name (code unit-test) results)
+	    (let ((start-time (get-internal-real-time)))
+	      (prog2 (format t "~A ~A~%" package test-name)
+		  (record-result test-name (code unit-test) results)
+		(format t "~A ~A ~F seconds~%~%" package test-name (/ (- (get-internal-real-time) start-time)
+								    internal-time-units-per-second))))
 	  else do
 	    (push test-name (missing-tests results)))))
     ;; Summarize and return the test results
@@ -979,7 +983,7 @@ If MERGE is NIL, then an error is signalled when a conflict occurs."
   (format stream "~& | Failed Form: ~S" (form result))
   (call-next-method)
   (when (extras result)
-    (format stream "~{~& | ~S => ~S~}~%" (extras result)))
+    (format stream "~{~& | ~S ~%   => ~S~}~%" (extras result)))
   (format stream "~& |~%"))
 
 (defmethod print-failures ((result failure-result) &optional

--- a/lisp-unit.lisp
+++ b/lisp-unit.lisp
@@ -291,7 +291,7 @@ assertion.")
          (setf
           ;; Unit test
           (gethash ,qname (package-table package t))
-          (make-instance 'unit-test :doc doc :code ',code :thunk (lambda () ,@body)))
+          (make-instance 'unit-test :doc doc :code ',code :thunk (lambda () ,@code)))
          ;; Tags
          (loop
           for tag in ',tag do

--- a/lisp-unit.lisp
+++ b/lisp-unit.lisp
@@ -812,6 +812,12 @@ output if a test fails.
   "Print a summary of all results to the stream."
   (let ((pass (pass results))
         (fail (fail results)))
+    (maphash (lambda (test-name result)
+               (when (fail result)
+                 (format stream " |    failed: ~A~%" test-name))) (database results))
+    (maphash (lambda (test-name result)
+               (when (exerr result)
+                 (format stream " |    error: ~A~%" test-name))) (database results)) 
     (format stream "~&Unit Test Summary~%")
     (format stream " | ~D assertions total~%" (+ pass fail))
     (format stream " | ~D passed~%" pass)

--- a/lisp-unit.lisp
+++ b/lisp-unit.lisp
@@ -283,6 +283,7 @@ assertion.")
 
 (defmacro define-test (name &body body)
   "Store the test in the test database."
+  (format t "defining test ~A~%" name)
   (let ((qname (gensym "NAME-")))
     (multiple-value-bind (doc tag code) (parse-body body)
       `(let* ((,qname (valid-test-name ',name))
@@ -785,6 +786,7 @@ output if a test fails.
 
 (defun record-result (test-name code results)
   "Run the test code and record the result."
+  (format t "Beginning test ~A~%" test-name)
   (let ((result (run-test-thunk test-name code)))
     ;; Store the result
     (setf (gethash test-name (database results)) result)
@@ -922,7 +924,7 @@ If MERGE is NIL, then an error is signalled when a conflict occurs."
 	    using (hash-value unit-test)
 	  if unit-test do
 	    (let ((start-time (get-internal-real-time)))
-	      (prog2 (format t "~A ~A~%" package test-name)
+	      (prog2 (let ((*package* (find-package "KEYWORD"))) (format t "~A ~S~%" package test-name))
 		  (record-result test-name (code unit-test) results)
 		(format t "~A ~A ~F seconds~%~%" package test-name (/ (- (get-internal-real-time) start-time)
 								    internal-time-units-per-second))))

--- a/lisp-unit.lisp
+++ b/lisp-unit.lisp
@@ -78,6 +78,7 @@ functions or even macros does not require reloading any tests.
            :test-documentation
            :remove-tests
            :run-tests
+           :run-1-test
            :use-debugger)
   ;; Functions for managing tags
   (:export :list-tags
@@ -945,6 +946,10 @@ If MERGE is NIL, then an error is signalled when a conflict occurs."
      (when *summarize-results*
        (summarize-results results))
      (return results))))
+
+(defun run-1-test (test-name)
+  "Run the test designated by the given TEST-NAME"
+  (run-tests (list test-name) (symbol-package test-name)))
 
 (defun run-tests (&optional (test-names :all) (package *package*))
   "Run the specified tests in package."


### PR DESCRIPTION
The expand-t-or-f macro expands to invalid code; assuming that a certain object is
funcallable. I don't believe this assumption is necessary. 